### PR TITLE
fix: exclude RetryLimitError from retry logic

### DIFF
--- a/pr_agent/algo/ai_handlers/openai_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/openai_ai_handler.py
@@ -1,8 +1,8 @@
 from os import environ
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 import openai
-from openai import APIError, AsyncOpenAI, RateLimitError, Timeout
-from retry import retry
+from openai import AsyncOpenAI
+from tenacity import retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt
 
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.config_loader import get_settings
@@ -38,8 +38,10 @@ class OpenAIHandler(BaseAiHandler):
         """
         return get_settings().get("OPENAI.DEPLOYMENT_ID", None)
 
-    @retry(exceptions=(APIError, Timeout, AttributeError, RateLimitError),
-           tries=OPENAI_RETRIES, delay=2, backoff=2, jitter=(1, 3))
+    @retry(
+        retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
+        stop=stop_after_attempt(OPENAI_RETRIES),
+    )
     async def chat_completion(self, model: str, system: str, user: str, temperature: float = 0.2):
         try:
             get_logger().info("System: ", system)
@@ -57,12 +59,12 @@ class OpenAIHandler(BaseAiHandler):
             get_logger().info("AI response", response=resp, messages=messages, finish_reason=finish_reason,
                               model=model, usage=usage)
             return resp, finish_reason
-        except (APIError, Timeout) as e:
-            get_logger().error("Error during OpenAI inference: ", e)
+        except openai.RateLimitError as e:
+            get_logger().error(f"Rate limit error during LLM inference: {e}")
             raise
-        except (RateLimitError) as e:
-            get_logger().error("Rate limit error during OpenAI inference: ", e)
+        except openai.APIError as e:
+            get_logger().warning(f"Error during LLM inference: {e}")
             raise
-        except (Exception) as e:
-            get_logger().error("Unknown error during OpenAI inference: ", e)
-            raise
+        except Exception as e:
+            get_logger().warning(f"Unknown error during LLM inference: {e}")
+            raise openai.APIError from e


### PR DESCRIPTION
### **User description**
## Description

이 PR은 3가지 수정을 담고 있습니다. 모두 `@retry`의 탈출 조건인 `RetryLimitError`를 제대로 식별하기 위한 작업입니다!

1. AIHandler에서 모두 `from tenacity import retry`를 사용하도록 변경했습니다. 내장 라이브러리 `import retry`를 더이상 사용하지 않아요.

2. `@retry`에서 명시적으로 `RateLimitError`를 exclude 하도록 수정했습니다.
    - 기존 코드에서 `APIError`를 include한 부분이 탈출 조건인 `RateLimitError`를 흡수해 retry를 탈출하지 못하는 상황입니다.
    ```py
    # AS-IS
    @retry(
        retry=retry_if_exception_type((openai.APIError, openai.APIConnectionError, openai.APITimeoutError)), # No retry on RateLimitError
        stop=stop_after_attempt(OPENAI_RETRIES)
    )
    ```
    - 이 부분을 `retry_if_not_exception_type`를 추가해 `APIError`를 include하면서도 `RateLimitError`를 exclude 했습니다.
    ```py
    # TO-BE
    @retry(
        retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
        stop=stop_after_attempt(OPENAI_RETRIES),
    )
     ```
    - NOTE: 클린코드 원칙에는 "코드에 주석을 달지 말 것!" 이라는 일침이 있는데, 코드만 보고 설명이 될 때 별도 주석이 필요없다는 뜻입니다. 이런 관점에서 기존 `# No retry on RateLimitError` 주석을 지웠어요.

3. AIHandler의 예외 핸들링 품질을 정규화했습니다.
  - 기존 `LiteLLMAIHandler`에 적용한`RateLimitError(error)` -> `APIError(warn)` -> `Exception(warn)` 구조를 AIHandler에 모두 적용했습니다.
    - 덤으로 `APITimeoutError`는 `APIError`를 상속받았으므로, 굳이 명시할 필요가 없어 지웠습니다.
    ```py
    # AS-IS
        except (openai.APIError, openai.APITimeoutError) as e:
            get_logger().warning(f"Error during LLM inference: {e}")
            raise

    # TO-BE
        except openai.APIError as e:
            get_logger().warning(f"Error during LLM inference: {e}")
            raise
    ```

---

### Test

**AS-IS**
- ![image](https://github.com/user-attachments/assets/94eeb234-5415-4af1-b4b0-b8fa46863e12)
- 기존 RateLimitError가 error 수준으로 호출되어도 5번 반복되는 모습. -- `@retry` 에 `openai.APIError`가 모든 상황을 흡수했습니다.

**TO-BE**
1) `RateLimitError`가 호출되는 상황
  - ![image](https://github.com/user-attachments/assets/24a6ff2a-df67-4b7c-b273-767c8e6c9040)
  - 의도대로 `RateLimitError`가 발생하면 1번만 호출하고 바로 탈출합니다.

2) (RateLimitError를 제외한) `APIError`가 호출되는 상황
  - ![image](https://github.com/user-attachments/assets/3e21ee7f-578e-475e-a6d8-e4e3771a25ad)
  - 의도대로 5번 `@retry`를 진행합니다.

3) 정상 실행
  - ![image](https://github.com/user-attachments/assets/f1861806-8209-4f63-9f03-3c7293bbf996)
  - 잘 됩니다.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored retry logic to exclude `RateLimitError` from retries.

- Standardized exception handling for OpenAI API errors.

- Replaced deprecated or incorrect retry decorators with `tenacity`.

- Improved logging for error and warning cases in AI handlers.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>langchain_ai_handler.py</strong><dd><code>Refactor retry and exception handling for Langchain AI handler</code></dd></summary>
<hr>

pr_agent/algo/ai_handlers/langchain_ai_handler.py

<li>Switched retry logic to use <code>tenacity</code>, excluding <code>RateLimitError</code>.<br> <li> Updated exception handling to log and re-raise errors more clearly.<br> <li> Improved error logging granularity for different OpenAI exceptions.<br> <li> Removed deprecated retry decorator and related imports.


</details>


  </td>
  <td><a href="https://github.com/group-3-sPRinter/pr-agent/pull/2/files#diff-7f2ff0d6468c62685f01a78c902ad6eb88af711872cf957f61710193db304456">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Update retry and error handling in LiteLLM AI handler</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Updated retry logic to exclude <code>RateLimitError</code> using <code>tenacity</code>.<br> <li> Simplified exception handling to focus on <code>APIError</code> and <code>RateLimitError</code>.<br> <li> Removed unnecessary exception types from retry conditions.


</details>


  </td>
  <td><a href="https://github.com/group-3-sPRinter/pr-agent/pull/2/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai_ai_handler.py</strong><dd><code>Refactor retry and exception handling in OpenAI AI handler</code></dd></summary>
<hr>

pr_agent/algo/ai_handlers/openai_ai_handler.py

<li>Replaced old retry decorator with <code>tenacity</code> to exclude <code>RateLimitError</code>.<br> <li> Standardized exception handling and logging for OpenAI errors.<br> <li> Improved error message clarity and propagation.<br> <li> Removed deprecated imports and retry logic.


</details>


  </td>
  <td><a href="https://github.com/group-3-sPRinter/pr-agent/pull/2/files#diff-b1102362ec51ffc9d9513f7a39cab5c62c1f188da389a2e9702160ebb26b1020">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>